### PR TITLE
Added listeners for accesDenied and accessDialogOpened events on publish...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 node_modules/
+.idea

--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -96,6 +96,12 @@ var OpenTokAngular = angular.module('opentok', [])
             // Make transcluding work manually by putting the children back in there
             $(element).append(oldChildren);
             scope.publisher.on({
+                accessDenied: function (event) {
+                    scope.$emit("otAccessDenied");
+                },
+                accessDialogOpened: function (event) {
+                    scope.$emit("otAccessDialogOpened");
+                },
                 accessAllowed: function(event) {
                     $(element).addClass("allowed");
                 },


### PR DESCRIPTION
Emitted events to allow the user to catch events regarding accessDenied and accessDialogOpened in the publisher object. This allows the user to bind custom error messages when these events occur, abstracting away the actual logic to the development code instead of having to modify the plugin code.
