### PR TITLE
Remove "real" jquery dependency, fix typo

### DIFF
--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -105,10 +105,10 @@ angular.module('opentok', [])
         },
         link: function(scope, element, attrs) {
           var props = scope.props() || {};
-          props.width = props.width ? props.width : angular.element(element).width();
-          props.height = props.height ? props.height : angular.element(element).height();
+          props.width = props.width ? props.width : element[0].offsetWidth;
+          props.height = props.height ? props.height : element[0].offsetHeight;
           var oldChildren = angular.element(element).children();
-          scope.publisher = TB.initPublisher(attrs.apikey || OTSession.session.apiKey,
+          scope.publisher = TB.initPublisher(attrs.apiKey || OTSession.session.apiKey,
             element[0], props, function(err) {
               if (err) {
                 scope.$emit('otPublisherError', err, scope.publisher);

--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -172,8 +172,8 @@ angular.module('opentok', [])
         link: function(scope, element) {
           var stream = scope.stream,
             props = scope.props() || {};
-          props.width = props.width ? props.width : angular.element(element).width();
-          props.height = props.height ? props.height : angular.element(element).height();
+          props.width = props.width ? props.width : element[0].offsetWidth;
+          props.height = props.height ? props.height : element[0].offsetHeight;
           var oldChildren = angular.element(element).children();
           var subscriber = OTSession.session.subscribe(stream, element[0], props, function(err) {
             if (err) {


### PR DESCRIPTION
`element.width()` and `element.height()` are "real" jquery functions, not available in jqlite that ships with angular. This uses the dom calculation, which is very standard now (since ie9). Also, angular attributes are automagically camelcased.