### PR TITLE
streamCreated: Checking stream exists before appending to OTSession.streams

### DIFF
--- a/opentok-angular.js
+++ b/opentok-angular.js
@@ -31,7 +31,9 @@ angular.module('opentok', [])
             },
             streamCreated: function(event) {
               $rootScope.$apply(function() {
-                OTSession.streams.push(event.stream);
+                if ( !_.findWhere(OTSession.streams, {id: event.stream.id})) {
+                  OTSession.streams.push(event.stream);
+                }
               });
             },
             streamDestroyed: function(event) {


### PR DESCRIPTION
Otherwise it's possible to end up with multiple instances of the same stream